### PR TITLE
Reorganize

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 A real-time web-based wargame map viewer and command tool. Built with:
 
-- **Next.js** frontend, hosted on Vercel at https://long-term-wargame.vercel.app
-- **Django + Channels (Daphne)** backend, hosted on Render
+- **Next.js** frontend, hosted on Vercel at https://umichwargame.vercel.app
+- **Django + Channels (Daphne)** backend, hosted on Render at https://umichwargame.onrender.com
 - **PostgreSQL** database, hosted on Neon
-- WebSocket support for live communication between roles/devices, hosted on redis cloud
+- **Redis** WebSocket backend, hosted at wss://umichwargame.onrender.com
 
 ---
 
@@ -28,6 +28,7 @@ LongTermWargame/
 │   └── wargamebackend/
 ├── frontend/             # Next.js frontend
 ├── Makefile              # Easy commands for running dev servers
+├── .env                  # gitignore'd. Info on what it contains below
 ```
 
 ---
@@ -84,12 +85,22 @@ make front
 In the root of the project, create a file named .env with the following structure:
 
 ```
-# Initially obtained from backend/wargamebackend/wargamebackend/settings.py
+# Generate with $ openssl rand -base64 48
 SECRET_KEY='your django secret key here'
 # Obtained by going to the Neon project's dashboard, clicking Connect, selecting Django, enable Connection Pooling, and looking at the .env tab
 DATABASE_URL='your neon database connection url, with connection pooling enabled, here'
 # Should be True in development, False in production
 DEBUG=True
+# These two should only be specified in production, and omitted in development
+NEXT_PUBLIC_BACKEND_URL='your backend server URL here'
+NEXT_PUBLIC_WS_URL='your WebSocket server URL here'
+# Will be emailed in production when there are internal server errors
+ADMINS='examplename:example@gmail.com,examplename2:example2@gmail.com'
+# Credentials of the email that will be used to send emails to admins when there are internal server errors
+# These are only necessary in production.
+EMAIL_HOST_USER='example3@gmail.com'
+# Obtained by generating an app password in google account settings
+EMAIL_HOST_PASSWORD='your password here'
 ```
 
 ---
@@ -103,19 +114,18 @@ DEBUG=True
 
 ## 💡 Role System
 
-- The root page (`/`) shows a role selector.
-- When a user selects a role (Commander, Observer, Field Unit), it's stored in `sessionStorage`.
-- This allows each device/tab to act independently.
+- `/roleselect` shows a role selector.
 - After role selection, users are redirected to `/game-instances/<join_code>/main-map/`, where the map is shown and role-specific UI can be rendered.
+- Users may only sign up for one role per game. They cannot sign up for a new role in a game unless a Gamemaster deletes their old role.
 
 ---
 
-## 📡 WebSocket Messaging (Optional)
+## 📡 WebSocket Messaging
 
-WebSocket code is included but currently disabled in the frontend. It supports:
+WebSocket code is included in the frontend. It supports:
 
-- Bi-directional real-time messaging via `/ws/game-instances/<join_code>/main-map/`
-- Broadcast to all connected devices
+- Bi-directional real-time messaging
+- Broadcast to connected devices
 - Handled by Django Channels + Daphne using ASGI
 
 ---

--- a/backend/wargamebackend/auth/authentication.py
+++ b/backend/wargamebackend/auth/authentication.py
@@ -1,3 +1,8 @@
+# This file defines an authentication class 
+# That specifies how the user who sent an HTTP request is identified.
+# It can determine whether a user isn't logged in
+# or has expired or invalid authentication credentials.
+
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import ExpiredTokenError, InvalidToken, AuthenticationFailed
 

--- a/backend/wargamebackend/auth/authorization.py
+++ b/backend/wargamebackend/auth/authorization.py
@@ -1,9 +1,14 @@
-import inspect
-from rest_framework import status
-from rest_framework.response import Response
+# This file provides two decorators, require_role_instance and require_any_role_instance
+# that can be used to specify which users are authorized to access an endpoint,
+# based on what role they have in the given game.
+# note that staff/superusers bypass all checks.
+
 from django.db.models import Model, QuerySet
 from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.response import Response
 from functools import wraps
+import inspect
 from datetime import datetime
 from wargamelogic.models import (
     RoleInstance

--- a/backend/wargamebackend/auth/middleware.py
+++ b/backend/wargamebackend/auth/middleware.py
@@ -1,3 +1,7 @@
+# The purpose of this file is similar to that of authentication.py,
+# but this one is specifically for authenticating WebSocket connections.
+# It is used in asgi.py.
+
 from django.contrib.auth.models import AnonymousUser
 from rest_framework_simplejwt.tokens import UntypedToken
 from rest_framework_simplejwt.authentication import JWTAuthentication
@@ -5,15 +9,9 @@ from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from channels.db import database_sync_to_async
 from http.cookies import SimpleCookie
 
-# For WebSocket authentication, I had ChatGPT generate this custom authentication
-# as opposed to the built-in AuthMiddlewareStack because that used sessions instead of JWT.
-# It made sense to make its authentication work the same way as it does for DRF,
-# i.e using JWT. This way, scope["user"] in a consumer should work the same way 
-# as request.user in DRF.
-class JWTAuthMiddleware:
+class CookieJWTAuthenticationWebSocketMiddleware:
     """
-    WebSocket middleware that authenticates users via JWT stored in cookies,
-    using SimpleJWT for validation (like DRF).
+    Authentication class for WebSockets that reads the JWT access token from a cookie.
     """
     def __init__(self, app):
         self.app = app

--- a/backend/wargamebackend/wargamebackend/asgi.py
+++ b/backend/wargamebackend/wargamebackend/asgi.py
@@ -15,12 +15,12 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wargamebackend.settings")
 django.setup()
 
 from channels.routing import ProtocolTypeRouter, URLRouter
-from auth.middleware import JWTAuthMiddleware
+from auth.middleware import CookieJWTAuthenticationWebSocketMiddleware 
 import wargamelogic.routing
 
 application = ProtocolTypeRouter({
     "http": get_asgi_application(),
-    "websocket": JWTAuthMiddleware(
+    "websocket": CookieJWTAuthenticationWebSocketMiddleware(
         URLRouter(wargamelogic.routing.websocket_urlpatterns)
     ),
 })

--- a/backend/wargamebackend/wargamebackend/settings.py
+++ b/backend/wargamebackend/wargamebackend/settings.py
@@ -176,6 +176,12 @@ CACHES = {
     }
 }
 
+raw_admins = os.getenv("ADMINS", "")
+ADMINS = [
+    tuple(admin.split(":", 1)) 
+    for admin in raw_admins.split(",") if admin
+]
+
 CORS_ALLOW_CREDENTIALS = True
 
 if DEBUG:
@@ -197,6 +203,9 @@ if DEBUG:
         "http://localhost",
         "http://127.0.0.1",
     ]
+
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
 else:
     ALLOWED_HOSTS = [
         "umichwargame.onrender.com",
@@ -216,6 +225,33 @@ else:
 
     SECURE_HSTS_SECONDS = 10
     SECURE_SSL_REDIRECT = True
+
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    # This assumes you're using a gmail account to send emails
+    EMAIL_HOST = "smtp.gmail.com"
+    EMAIL_PORT = 587
+    EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+    EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+    EMAIL_USE_TLS = True
+
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {
+            "mail_admins": {
+                "level": "ERROR",
+                "class": "django.utils.log.AdminEmailHandler",
+                "include_html": True,
+            },
+        },
+        "loggers": {
+            "django.request": {
+                "handlers": ["mail_admins"],
+                "level": "ERROR",
+                "propagate": True,
+            },
+        },
+    }
 
 
 # Static files (CSS, JavaScript, Images)

--- a/backend/wargamebackend/wargamelogic/consumers.py
+++ b/backend/wargamebackend/wargamelogic/consumers.py
@@ -230,6 +230,10 @@ class GameConsumer(AsyncWebsocketConsumer):
         redis_client.hset(role_key, user.id, json.dumps(data))
 
         return self.team_group, data
+    
+
+    async def handle_users_update_ready(self, data):
+        return self.team_group, data
 
 
     async def handle_timer_get_finish_time(self, data):
@@ -412,10 +416,11 @@ def get_user_transfer_groups(join_code, teams, roles, role_instance):
 
     if user_role_name == "Gamemaster":
         transfer_to_groups += [(t.name, r.name) for r in roles if r.name != "Gamemaster" for t in teams if t.name != gamemaster_team_name]
+    else:
+        transfer_from_groups += [(gamemaster_team_name, "Gamemaster")]
 
     if user_role_name == "Combatant Commander":
         transfer_to_groups += [(user_team_name, r.name) for r in roles if r.is_chief_of_staff]
-        transfer_from_groups += [(gamemaster_team_name, "Gamemaster")]
 
     if role_instance["role"]["is_chief_of_staff"]:
         transfer_to_groups += [(user_team_name, r.name) for r in roles if r.is_logistics and r.is_commander and r.branch.name == role_instance["role"]["branch"]["name"]]

--- a/backend/wargamebackend/wargamelogic/view_sets.py
+++ b/backend/wargamebackend/wargamelogic/view_sets.py
@@ -13,7 +13,7 @@ from wargamelogic.serializers import (
     TeamSerializer, BranchSerializer, RoleSerializer, UnitSerializer, UnitBranchSerializer, AttackSerializer, AbilitySerializer, TileSerializer, LandmarkSerializer,
     GameInstanceSerializer, TeamInstanceSerializer, RoleInstanceSerializer, TeamInstanceRolePointsSerializer, UnitInstanceSerializer, LandmarkInstanceSerializer, LandmarkInstanceTileSerializer,
 )
-from wargamelogic.check_roles import (
+from auth.authorization import (
     require_role_instance, require_any_role_instance, get_object_and_related_with_cache_or_404
 )
 

--- a/backend/wargamebackend/wargamelogic/views/delete.py
+++ b/backend/wargamebackend/wargamelogic/views/delete.py
@@ -8,7 +8,7 @@ from wargamelogic.consumers import get_redis_client
 from wargamelogic.models.dynamic import (
     GameInstance
 )
-from wargamelogic.check_roles import (
+from auth.authorization import (
     require_role_instance
 )
 

--- a/backend/wargamebackend/wargamelogic/views/get.py
+++ b/backend/wargamebackend/wargamelogic/views/get.py
@@ -14,7 +14,7 @@ from wargamelogic.serializers import (
     TeamSerializer, RoleSerializer, UnitSerializer, AttackSerializer, AbilitySerializer, LandmarkSerializer, TileSerializer,
     TeamInstanceSerializer, RoleInstanceSerializer, TeamInstanceRolePointsSerializer, UnitInstanceSerializer, LandmarkInstanceSerializer,
 )
-from wargamelogic.check_roles import (
+from auth.authorization import (
     require_role_instance, require_any_role_instance
 )
 

--- a/backend/wargamebackend/wargamelogic/views/patch.py
+++ b/backend/wargamebackend/wargamelogic/views/patch.py
@@ -13,7 +13,7 @@ from wargamelogic.models.dynamic import (
 from wargamelogic.serializers import (
     TeamInstanceRolePointsSerializer, UnitInstanceSerializer
 )
-from wargamelogic.check_roles import (
+from auth.authorization import (
     require_any_role_instance, get_object_and_related_with_cache_or_404, get_user_role_instances
 )
 

--- a/backend/wargamebackend/wargamelogic/views/post.py
+++ b/backend/wargamebackend/wargamelogic/views/post.py
@@ -1,9 +1,10 @@
+from django.shortcuts import get_object_or_404
+from django.db import transaction
 from rest_framework import status
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from auth.authentication import CookieJWTAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from django.shortcuts import get_object_or_404
 from wargamelogic.models.static import (
     Team, Role, Unit, Tile
 )
@@ -177,6 +178,7 @@ def create_role_instance(request):
         'team_instance.team.name': lambda request, kwargs: request.data.get("team_name"),
     }
 ])
+@transaction.atomic
 def create_unit_instance(request):
     join_code = request.data.get("join_code")
     team_name = request.data.get("team_name")

--- a/backend/wargamebackend/wargamelogic/views/post.py
+++ b/backend/wargamebackend/wargamelogic/views/post.py
@@ -13,7 +13,7 @@ from wargamelogic.models.dynamic import (
 from wargamelogic.serializers import (
     RoleInstanceSerializer, UnitInstanceSerializer
 )
-from wargamelogic.check_roles import (
+from auth.authorization import (
     require_any_role_instance
 )
 

--- a/backend/wargamebackend/wargamelogic/views/post.py
+++ b/backend/wargamebackend/wargamelogic/views/post.py
@@ -22,6 +22,7 @@ from auth.authorization import (
 @api_view(['POST'])
 @authentication_classes([CookieJWTAuthentication])
 @permission_classes([IsAuthenticated])
+@transaction.atomic
 def create_game_instance(request):
     join_code = request.data.get("join_code")
     if not join_code:

--- a/frontend/src/components/Ready.tsx
+++ b/frontend/src/components/Ready.tsx
@@ -19,6 +19,9 @@ export default function Ready({ socket, socketReady, roleInstance }: ReadyProps)
     const toggleReady = () => {
         if (!socketReady || !socket || !roleInstance) return;
 
+        // TODO: send an HTTP request, and only send data over socket
+        // upon successful response
+
         const newReady = !ready;
         setReady(newReady);
 

--- a/frontend/src/components/TurnSystem.tsx
+++ b/frontend/src/components/TurnSystem.tsx
@@ -58,7 +58,11 @@ export default function TurnSystem({ socket, socketReady, roleInstance, roleInst
     // Increment turn
     const goToNextTurn = () => {
         if (!socketReady || !socket) return;
+        // TODO: should probably make it so only a gamemaster actually increments this
+
         const newTurn = turn + 1;
+        // TODO: send an HTTP request, and only send data over socket
+        // upon successful response
 
         socket.send(JSON.stringify({
             channel: "turns",


### PR DESCRIPTION
Move check_roles.py and rename it. Email site admins when an internal error occurs in production (.env file needs to be updated accordingly). Make some backend operations atomic (although this can be improved; for example, send_points and use_attack can run concurrently, which could cause issues if both modify the same TeamInstanceRolePoints record, so this is only a slight improvement over before). Only broadcast ready update messages on the WebSocket to users on the same team and gamemasters. Fix a bug where users wouldn't receive a message over the WebSocket when a gamemaster sent them points.